### PR TITLE
Use official builds now that chef/chef#8598 is merged and built

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,8 +11,8 @@ provisioner:
   attributes:
     chef_license: accept
     effortless:
-      origin: ncerny
-      pkg: infra-client
+      origin: chef
+      pkg: chef-client
       channel: unstable
 
 verifier:


### PR DESCRIPTION
https://github.com/chef/chef/pull/8598 is merged, and built (but not yet promoted), so we can start using those builds in the unstable channel.


Signed-off-by: Nathan Cerny <ncerny@gmail.com>